### PR TITLE
drivers: hv: new callback function

### DIFF
--- a/drivers/hv/hv_balloon.c
+++ b/drivers/hv/hv_balloon.c
@@ -1411,7 +1411,7 @@ static void balloon_down(struct hv_dynmem_device *dm,
 	dm->state = DM_INITIALIZED;
 }
 
-static void balloon_onchannelcallback(void *context);
+static void balloon_onchannelcallback(struct vmbus_channel *chan, void *context);
 
 static int dm_thread_func(void *dm_dev)
 {
@@ -1515,7 +1515,7 @@ static void cap_resp(struct hv_dynmem_device *dm,
 	complete(&dm->host_event);
 }
 
-static void balloon_onchannelcallback(void *context)
+static void balloon_onchannelcallback(struct vmbus_channel *chan, void *context)
 {
 	struct hv_device *dev = context;
 	u32 recvlen;
@@ -1774,7 +1774,7 @@ static int balloon_connect_vsp(struct hv_device *dev)
 	 */
 	dev->channel->max_pkt_size = HV_HYP_PAGE_SIZE * 2;
 
-	ret = vmbus_open(dev->channel, dm_ring_size, dm_ring_size, NULL, 0,
+	ret = vmbus_open_channel(dev->channel, dm_ring_size, dm_ring_size, NULL, 0,
 			 balloon_onchannelcallback, dev);
 	if (ret)
 		return ret;

--- a/drivers/hv/hv_fcopy.c
+++ b/drivers/hv/hv_fcopy.c
@@ -223,7 +223,7 @@ fcopy_respond_to_host(int error)
 				VM_PKT_DATA_INBAND, 0);
 }
 
-void hv_fcopy_onchannelcallback(void *context)
+void hv_fcopy_onchannelcallback(struct vmbus_channel *chan, void *context)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;

--- a/drivers/hv/hv_kvp.c
+++ b/drivers/hv/hv_kvp.c
@@ -632,7 +632,7 @@ response_done:
  * we stash away the transaction state in a set of global variables.
  */
 
-void hv_kvp_onchannelcallback(void *context)
+void hv_kvp_onchannelcallback(struct vmbus_channel *chan, void *context)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;

--- a/drivers/hv/hv_snapshot.c
+++ b/drivers/hv/hv_snapshot.c
@@ -288,7 +288,7 @@ vss_respond_to_host(int error)
  * The host ensures that only one VSS transaction can be active at a time.
  */
 
-void hv_vss_onchannelcallback(void *context)
+void hv_vss_onchannelcallback(struct vmbus_channel *chan, void *context)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;

--- a/drivers/hv/hv_util.c
+++ b/drivers/hv/hv_util.c
@@ -115,7 +115,7 @@ static int hv_shutdown_init(struct hv_util_service *srv)
 	return 0;
 }
 
-static void shutdown_onchannelcallback(void *context);
+static void shutdown_onchannelcallback(struct vmbus_channel *, void *context);
 static struct hv_util_service util_shutdown = {
 	.util_cb = shutdown_onchannelcallback,
 	.util_init = hv_shutdown_init,
@@ -125,7 +125,7 @@ static int hv_timesync_init(struct hv_util_service *srv);
 static int hv_timesync_pre_suspend(void);
 static void hv_timesync_deinit(void);
 
-static void timesync_onchannelcallback(void *context);
+static void timesync_onchannelcallback(struct vmbus_channel *, void *context);
 static struct hv_util_service util_timesynch = {
 	.util_cb = timesync_onchannelcallback,
 	.util_init = hv_timesync_init,
@@ -133,7 +133,7 @@ static struct hv_util_service util_timesynch = {
 	.util_deinit = hv_timesync_deinit,
 };
 
-static void heartbeat_onchannelcallback(void *context);
+static void heartbeat_onchannelcallback(struct vmbus_channel *, void *context);
 static struct hv_util_service util_heartbeat = {
 	.util_cb = heartbeat_onchannelcallback,
 };
@@ -182,7 +182,7 @@ static DECLARE_WORK(shutdown_work, perform_shutdown);
  */
 static DECLARE_WORK(restart_work, perform_restart);
 
-static void shutdown_onchannelcallback(void *context)
+static void shutdown_onchannelcallback(struct vmbus_channel *, void *context)
 {
 	struct vmbus_channel *channel = context;
 	struct work_struct *work = NULL;
@@ -391,7 +391,7 @@ static inline void adj_guesttime(u64 hosttime, u64 reftime, u8 adj_flags)
 /*
  * Time Sync Channel message handler.
  */
-static void timesync_onchannelcallback(void *context)
+static void timesync_onchannelcallback(struct vmbus_channel *, void *context)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;
@@ -484,7 +484,7 @@ static void timesync_onchannelcallback(void *context)
  * Every two seconds, Hyper-V send us a heartbeat request message.
  * we respond to this message, and Hyper-V knows we are alive.
  */
-static void heartbeat_onchannelcallback(void *context)
+static void heartbeat_onchannelcallback(struct vmbus_channel *, void *context)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;
@@ -586,7 +586,7 @@ static int util_probe(struct hv_device *dev,
 
 	hv_set_drvdata(dev, srv);
 
-	ret = vmbus_open(dev->channel, HV_UTIL_RING_SEND_SIZE,
+	ret = vmbus_open_channel(dev->channel, HV_UTIL_RING_SEND_SIZE,
 			 HV_UTIL_RING_RECV_SIZE, NULL, 0, srv->util_cb,
 			 dev->channel);
 	if (ret)
@@ -644,7 +644,7 @@ static int util_resume(struct hv_device *dev)
 			return ret;
 	}
 
-	ret = vmbus_open(dev->channel, HV_UTIL_RING_SEND_SIZE,
+	ret = vmbus_open_channel(dev->channel, HV_UTIL_RING_SEND_SIZE,
 			 HV_UTIL_RING_RECV_SIZE, NULL, 0, srv->util_cb,
 			 dev->channel);
 	return ret;

--- a/drivers/hv/hyperv_vmbus.h
+++ b/drivers/hv/hyperv_vmbus.h
@@ -362,19 +362,19 @@ int hv_kvp_init(struct hv_util_service *srv);
 void hv_kvp_deinit(void);
 int hv_kvp_pre_suspend(void);
 int hv_kvp_pre_resume(void);
-void hv_kvp_onchannelcallback(void *context);
+void hv_kvp_onchannelcallback(struct vmbus_channel *chan, void *context);
 
 int hv_vss_init(struct hv_util_service *srv);
 void hv_vss_deinit(void);
 int hv_vss_pre_suspend(void);
 int hv_vss_pre_resume(void);
-void hv_vss_onchannelcallback(void *context);
+void hv_vss_onchannelcallback(struct vmbus_channel *chan, void *context);
 
 int hv_fcopy_init(struct hv_util_service *srv);
 void hv_fcopy_deinit(void);
 int hv_fcopy_pre_suspend(void);
 int hv_fcopy_pre_resume(void);
-void hv_fcopy_onchannelcallback(void *context);
+void hv_fcopy_onchannelcallback(struct vmbus_channel *chan, void *context);
 void vmbus_initiate_unload(bool crash);
 
 static inline void hv_poll_channel(struct vmbus_channel *channel,

--- a/include/linux/hyperv.h
+++ b/include/linux/hyperv.h
@@ -1553,7 +1553,7 @@ void vmbus_free_mmio(resource_size_t start, resource_size_t size);
 struct hv_util_service {
 	u8 *recv_buffer;
 	void *channel;
-	void (*util_cb)(void *);
+	void (*util_cb)(struct vmbus_channel *, void *);
 	int (*util_init)(struct hv_util_service *);
 	void (*util_deinit)(void);
 	int (*util_pre_suspend)(void);

--- a/include/linux/hyperv.h
+++ b/include/linux/hyperv.h
@@ -863,7 +863,11 @@ struct vmbus_channel {
 
 	/* Channel callback's invoked in softirq context */
 	struct tasklet_struct callback_event;
-	void (*onchannel_callback)(void *context);
+	bool old_callback_api;
+	union {
+		void (*onchannel_callback_old)(void *context);
+		void (*onchannel_callback)(struct vmbus_channel *chan, void *context);
+	};
 	void *channel_callback_context;
 
 	void (*change_target_cpu_callback)(struct vmbus_channel *channel,
@@ -1175,7 +1179,10 @@ int vmbus_alloc_ring(struct vmbus_channel *channel,
 void vmbus_free_ring(struct vmbus_channel *channel);
 
 int vmbus_connect_ring(struct vmbus_channel *channel,
-		       void (*onchannel_callback)(void *context),
+		       void (*onchannel_callback_old)(void *context),
+		       void *context);
+int vmbus_channel_connect_ring(struct vmbus_channel *channel,
+		       void (*onchannel_callback)(struct vmbus_channel *, void *context),
 		       void *context);
 int vmbus_disconnect_ring(struct vmbus_channel *channel);
 
@@ -1184,7 +1191,15 @@ extern int vmbus_open(struct vmbus_channel *channel,
 			    u32 recv_ringbuffersize,
 			    void *userdata,
 			    u32 userdatalen,
-			    void (*onchannel_callback)(void *context),
+			    void (*onchannel_callback_old)(void *context),
+			    void *context);
+
+extern int vmbus_open_channel(struct vmbus_channel *channel,
+			    u32 send_ringbuffersize,
+			    u32 recv_ringbuffersize,
+			    void *userdata,
+			    u32 userdatalen,
+			    void (*onchannel_callback)(struct vmbus_channel *chan, void *context),
 			    void *context);
 
 extern void vmbus_close(struct vmbus_channel *channel);


### PR DESCRIPTION
Create new functions `vmbus_open_channel` and `vmbus_channel_connect_ring`  which require an additional argument for the call back function. The resulting callback function is `void (*onchannelcallback)(struct vmbus_channel *, void *context)`

TODO
- consider using typedef
- new commit proprogating changes to other drivers
- clean up commit