### PR TITLE
drivers: hv: use new api for channel callbacks with hv drivers

### DIFF
--- a/drivers/hv/channel.c
+++ b/drivers/hv/channel.c
@@ -651,8 +651,8 @@ static void vmbus_free_requestor(struct vmbus_requestor *rqstor)
 }
 
 static int __vmbus_open(struct vmbus_channel *newchannel,
-		       void *userdata, u32 userdatalen,
-		       void (*onchannelcallback)(void *context), void *context)
+		       void *userdata, u32 userdatalen, bool channelapiv1,
+		       void *onchannelcallback, void *context)
 {
 	struct vmbus_channel_open_channel *open_msg;
 	struct vmbus_channel_msginfo *open_info = NULL;
@@ -677,7 +677,15 @@ static int __vmbus_open(struct vmbus_channel *newchannel,
 	}
 
 	newchannel->state = CHANNEL_OPENING_STATE;
-	newchannel->onchannel_callback = onchannelcallback;
+
+	if (channelapiv1) {
+		newchannel->onchannel_callback = NULL;
+		newchannel->onchannel_callback_v1 = onchannelcallback;
+	} else {
+		newchannel->onchannel_callback = onchannelcallback;
+		newchannel->onchannel_callback_v1 = NULL;
+	}
+
 	newchannel->channel_callback_context = context;
 
 	if (!newchannel->max_pkt_size)
@@ -794,9 +802,21 @@ error_clean_ring:
 int vmbus_connect_ring(struct vmbus_channel *newchannel,
 		       void (*onchannelcallback)(void *context), void *context)
 {
-	return  __vmbus_open(newchannel, NULL, 0, onchannelcallback, context);
+	bool channelapiv1 = true;
+	return  __vmbus_open(newchannel, NULL, 0, channelapiv1, onchannelcallback, context);
 }
 EXPORT_SYMBOL_GPL(vmbus_connect_ring);
+
+/*
+ * vmbus_connect_ring - Open the channel but reuse ring buffer
+ */
+int vmbus_connect_ring_channel(struct vmbus_channel *newchannel,
+		       onchannel_t *onchannelcallback, void *context)
+{
+	bool channelapiv1 = false;
+	return  __vmbus_open(newchannel, NULL, 0, channelapiv1, onchannelcallback, context);
+}
+EXPORT_SYMBOL_GPL(vmbus_connect_ring_channel);
 
 /*
  * vmbus_open - Open the specified channel.
@@ -807,6 +827,7 @@ int vmbus_open(struct vmbus_channel *newchannel,
 	       void (*onchannelcallback)(void *context), void *context)
 {
 	int err;
+	bool channelapiv1 = true;
 
 	err = vmbus_alloc_ring(newchannel, send_ringbuffer_size,
 			       recv_ringbuffer_size);
@@ -814,13 +835,38 @@ int vmbus_open(struct vmbus_channel *newchannel,
 		return err;
 
 	err = __vmbus_open(newchannel, userdata, userdatalen,
-			   onchannelcallback, context);
+			   channelapiv1, onchannelcallback, context);
 	if (err)
 		vmbus_free_ring(newchannel);
 
 	return err;
 }
 EXPORT_SYMBOL_GPL(vmbus_open);
+
+/*
+ * vmbus_open - Open the specified channel.
+ */
+int vmbus_open_channel(struct vmbus_channel *newchannel,
+	       u32 send_ringbuffer_size, u32 recv_ringbuffer_size,
+	       void *userdata, u32 userdatalen,
+	       onchannel_t *onchannelcallback, void *context)
+{
+	int err;
+	bool channelapiv1 = false;
+
+	err = vmbus_alloc_ring(newchannel, send_ringbuffer_size,
+			       recv_ringbuffer_size);
+	if (err)
+		return err;
+
+	err = __vmbus_open(newchannel, userdata, userdatalen,
+			   channelapiv1, onchannelcallback, context);
+	if (err)
+		vmbus_free_ring(newchannel);
+
+	return err;
+}
+EXPORT_SYMBOL_GPL(vmbus_open_channel);
 
 /*
  * vmbus_teardown_gpadl -Teardown the specified GPADL handle
@@ -912,6 +958,7 @@ void vmbus_reset_channel_cb(struct vmbus_channel *channel)
 	/* See the inline comments in vmbus_chan_sched(). */
 	spin_lock_irqsave(&channel->sched_lock, flags);
 	channel->onchannel_callback = NULL;
+	channel->onchannel_callback_v1 = NULL;
 	spin_unlock_irqrestore(&channel->sched_lock, flags);
 
 	channel->sc_creation_callback = NULL;

--- a/drivers/hv/connection.c
+++ b/drivers/hv/connection.c
@@ -378,7 +378,8 @@ struct vmbus_channel *relid2channel(u32 relid)
 void vmbus_on_event(unsigned long data)
 {
 	struct vmbus_channel *channel = (void *) data;
-	void (*callback_fn)(void *context);
+	void (*callback_fn_v1)(void *context);
+	onchannel_t *callback_fn;
 
 	trace_vmbus_on_event(channel);
 
@@ -388,12 +389,16 @@ void vmbus_on_event(unsigned long data)
 	 * there is no driver handling the device. An
 	 * unloading driver sets the onchannel_callback to NULL.
 	 */
-	callback_fn = READ_ONCE(channel->onchannel_callback);
-	if (unlikely(!callback_fn))
+	if (channel->onchannel_callback_v1 != NULL) {
+		callback_fn_v1 = READ_ONCE(channel->onchannel_callback_v1);
+		(*callback_fn_v1)(channel->channel_callback_context);
+	} else if (channel->onchannel_callback != NULL) {
+		callback_fn = READ_ONCE(channel->onchannel_callback);
+		(*callback_fn)(channel->channel_callback_context, channel);
+	} else {
 		return;
-
-	(*callback_fn)(channel->channel_callback_context);
-
+	}
+	
 	if (channel->callback_mode != HV_CALL_BATCHED)
 		return;
 

--- a/drivers/hv/hv_balloon.c
+++ b/drivers/hv/hv_balloon.c
@@ -1407,7 +1407,7 @@ static void balloon_down(struct hv_dynmem_device *dm,
 	dm->state = DM_INITIALIZED;
 }
 
-static void balloon_onchannelcallback(void *context);
+static void balloon_onchannelcallback(void *context, struct vmbus_channel *chan);
 
 static int dm_thread_func(void *dm_dev)
 {
@@ -1511,7 +1511,7 @@ static void cap_resp(struct hv_dynmem_device *dm,
 	complete(&dm->host_event);
 }
 
-static void balloon_onchannelcallback(void *context)
+static void balloon_onchannelcallback(void *context, struct vmbus_channel *chan)
 {
 	struct hv_device *dev = context;
 	u32 recvlen;
@@ -1770,7 +1770,7 @@ static int balloon_connect_vsp(struct hv_device *dev)
 	 */
 	dev->channel->max_pkt_size = HV_HYP_PAGE_SIZE * 2;
 
-	ret = vmbus_open(dev->channel, dm_ring_size, dm_ring_size, NULL, 0,
+	ret = vmbus_open_channel(dev->channel, dm_ring_size, dm_ring_size, NULL, 0,
 			 balloon_onchannelcallback, dev);
 	if (ret)
 		return ret;

--- a/drivers/hv/hv_fcopy.c
+++ b/drivers/hv/hv_fcopy.c
@@ -223,7 +223,7 @@ fcopy_respond_to_host(int error)
 				VM_PKT_DATA_INBAND, 0);
 }
 
-void hv_fcopy_onchannelcallback(void *context)
+void hv_fcopy_onchannelcallback(void *context, struct vmbus_channel *chan)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;

--- a/drivers/hv/hv_kvp.c
+++ b/drivers/hv/hv_kvp.c
@@ -632,7 +632,7 @@ response_done:
  * we stash away the transaction state in a set of global variables.
  */
 
-void hv_kvp_onchannelcallback(void *context)
+void hv_kvp_onchannelcallback(void *context, struct vmbus_channel *chan)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;

--- a/drivers/hv/hv_snapshot.c
+++ b/drivers/hv/hv_snapshot.c
@@ -288,7 +288,7 @@ vss_respond_to_host(int error)
  * The host ensures that only one VSS transaction can be active at a time.
  */
 
-void hv_vss_onchannelcallback(void *context)
+void hv_vss_onchannelcallback(void *context, struct vmbus_channel *chan)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;

--- a/drivers/hv/hyperv_vmbus.h
+++ b/drivers/hv/hyperv_vmbus.h
@@ -373,19 +373,19 @@ int hv_kvp_init(struct hv_util_service *srv);
 void hv_kvp_deinit(void);
 int hv_kvp_pre_suspend(void);
 int hv_kvp_pre_resume(void);
-void hv_kvp_onchannelcallback(void *context);
+onchannel_t hv_kvp_onchannelcallback;
 
 int hv_vss_init(struct hv_util_service *srv);
 void hv_vss_deinit(void);
 int hv_vss_pre_suspend(void);
 int hv_vss_pre_resume(void);
-void hv_vss_onchannelcallback(void *context);
+onchannel_t hv_vss_onchannelcallback;
 
 int hv_fcopy_init(struct hv_util_service *srv);
 void hv_fcopy_deinit(void);
 int hv_fcopy_pre_suspend(void);
 int hv_fcopy_pre_resume(void);
-void hv_fcopy_onchannelcallback(void *context);
+onchannel_t hv_fcopy_onchannelcallback;
 void vmbus_initiate_unload(bool crash);
 
 static inline void hv_poll_channel(struct vmbus_channel *channel,

--- a/drivers/hv/vmbus_drv.c
+++ b/drivers/hv/vmbus_drv.c
@@ -1224,7 +1224,8 @@ static void vmbus_chan_sched(struct hv_per_cpu_context *hv_cpu)
 		return;
 
 	for_each_set_bit(relid, recv_int_page, maxbits) {
-		void (*callback_fn)(void *context);
+		void (*callback_fn_v1)(void *context);
+		onchannel_t *callback_fn;
 		struct vmbus_channel *channel;
 
 		if (!sync_test_and_clear_bit(relid, recv_int_page))
@@ -1259,9 +1260,15 @@ static void vmbus_chan_sched(struct hv_per_cpu_context *hv_cpu)
 		 */
 		spin_lock(&channel->sched_lock);
 
-		callback_fn = channel->onchannel_callback;
-		if (unlikely(callback_fn == NULL))
+		bool channelapiv1 = false;
+		if (channel->onchannel_callback_v1 != NULL) {
+			callback_fn_v1 = channel->onchannel_callback_v1;
+		} else if (channel->onchannel_callback != NULL) {
+			callback_fn =channel->onchannel_callback;
+			channelapiv1 = true;
+		} else {
 			goto sched_unlock;
+		}
 
 		trace_vmbus_chan_sched(channel);
 
@@ -1269,7 +1276,11 @@ static void vmbus_chan_sched(struct hv_per_cpu_context *hv_cpu)
 
 		switch (channel->callback_mode) {
 		case HV_CALL_ISR:
-			(*callback_fn)(channel->channel_callback_context);
+			if (channelapiv1) {
+				(*callback_fn_v1)(channel->channel_callback_context);
+			} else {
+				(*callback_fn)(channel->channel_callback_context, channel);
+			}
 			break;
 
 		case HV_CALL_BATCHED:

--- a/include/linux/hyperv.h
+++ b/include/linux/hyperv.h
@@ -814,6 +814,8 @@ struct vmbus_gpadl {
 	void *buffer;
 };
 
+typedef void onchannel_t(void *context, struct vmbus_channel *chan);
+
 struct vmbus_channel {
 	struct list_head listentry;
 
@@ -863,7 +865,8 @@ struct vmbus_channel {
 
 	/* Channel callback's invoked in softirq context */
 	struct tasklet_struct callback_event;
-	void (*onchannel_callback)(void *context);
+	void (*onchannel_callback_v1)(void *context);
+	onchannel_t *onchannel_callback;
 	void *channel_callback_context;
 
 	void (*change_target_cpu_callback)(struct vmbus_channel *channel,
@@ -1177,6 +1180,9 @@ void vmbus_free_ring(struct vmbus_channel *channel);
 int vmbus_connect_ring(struct vmbus_channel *channel,
 		       void (*onchannel_callback)(void *context),
 		       void *context);
+int vmbus_connect_ring_channel(struct vmbus_channel *channel,
+		       onchannel_t *onchannel_callback,
+		       void *context);
 int vmbus_disconnect_ring(struct vmbus_channel *channel);
 
 extern int vmbus_open(struct vmbus_channel *channel,
@@ -1185,6 +1191,14 @@ extern int vmbus_open(struct vmbus_channel *channel,
 			    void *userdata,
 			    u32 userdatalen,
 			    void (*onchannel_callback)(void *context),
+			    void *context);
+
+extern int vmbus_open_channel(struct vmbus_channel *channel,
+			    u32 send_ringbuffersize,
+			    u32 recv_ringbuffersize,
+			    void *userdata,
+			    u32 userdatalen,
+			    onchannel_t *onchannelcallback,
 			    void *context);
 
 extern void vmbus_close(struct vmbus_channel *channel);

--- a/include/linux/hyperv.h
+++ b/include/linux/hyperv.h
@@ -1552,7 +1552,7 @@ void vmbus_free_mmio(resource_size_t start, resource_size_t size);
 struct hv_util_service {
 	u8 *recv_buffer;
 	void *channel;
-	void (*util_cb)(void *);
+	onchannel_t *util_cb;
 	int (*util_init)(struct hv_util_service *);
 	void (*util_deinit)(void);
 	int (*util_pre_suspend)(void);


### PR DESCRIPTION
This patchset introduces new function apis for "vmbus_open" as "vmbus_open_channel" and "vmbus_connect_ring" as "vmbus_connect_ring_channel" which add an additional parameter for the vmbus channel.  The current api passes the channel as a part of the context. This new function api is in preparation for Rust integration.

Rust code is built to create sound code blocks and to prevent the user from ever entering into undefined behavior. Rust will need a new type state to prevent writing and reading from channels which are not yet open. However, this requires the channel to be separate from the context as the channel may not have been opened yet. 

An implementation of this can be seen at https://github.com/wedsonaf/linux/tree/hv

Background
vmbus_channel is given callback function by __vmbus_open
__vmbus_open called by vmbus_open
drvier -> vmbus_add_channel_work -> vmbus_open -> __vmbus_open -> sets channel callback function

**API changes**
vmbus_open -> vmbus_open_channel
vmbus_connect_ring -> vmbus_connect_ring_channel

**internal function changes**
- __vmbus_open
    - now accepts a boolean on if it should use the v1 callback api
    
- vmbus_channel struct 
    - original callback function renamed to `onchannel_callback_v1`
    `void (*onchannel_callback)(void *context);` -> `void (*onchannel_callback_v1)(void *context);`
    - added new callback function which requires context and channel
    `typedef void onchannel_t(void *context, struct vmbus_channel *chan);`
     `void (*onchannel_callback_v1)(void *context);`


Checks:
- [ ] Builds with CONFIG_HYPERV
- [ ] Builds without CONFIG_HYPERV

TODO
- clean up commits
- finish all hv drivers
- cleanup v1 api
- test
- send to linux-hyperv