### PR TITLE
drivers: hv: use new api for channel callbacks with hv drivers 

### DIFF
--- a/drivers/gpu/drm/hyperv/hyperv_drm_proto.c
+++ b/drivers/gpu/drm/hyperv/hyperv_drm_proto.c
@@ -448,7 +448,7 @@ static void hyperv_receive_sub(struct hv_device *hdev)
 	}
 }
 
-static void hyperv_receive(void *ctx)
+static void hyperv_receive(void *ctx, struct vmbus_channel *channel)
 {
 	struct hv_device *hdev = ctx;
 	struct hyperv_drm_device *hv = hv_get_drvdata(hdev);
@@ -478,7 +478,7 @@ int hyperv_connect_vsp(struct hv_device *hdev)
 	struct drm_device *dev = &hv->dev;
 	int ret;
 
-	ret = vmbus_open(hdev->channel, VMBUS_RING_BUFSIZE, VMBUS_RING_BUFSIZE,
+	ret = vmbus_open_channel(hdev->channel, VMBUS_RING_BUFSIZE, VMBUS_RING_BUFSIZE,
 			 NULL, 0, hyperv_receive, hdev);
 	if (ret) {
 		drm_err(dev, "Unable to open vmbus channel\n");

--- a/drivers/hid/hid-hyperv.c
+++ b/drivers/hid/hid-hyperv.c
@@ -305,7 +305,7 @@ static void mousevsc_on_receive(struct hv_device *device,
 
 }
 
-static void mousevsc_on_channel_callback(void *context)
+static void mousevsc_on_channel_callback(void *context, struct vmbus_channel *channel)
 {
 	struct hv_device *device = context;
 	struct vmpacket_descriptor *desc;
@@ -445,7 +445,7 @@ static int mousevsc_probe(struct hv_device *device,
 	if (!input_dev)
 		return -ENOMEM;
 
-	ret = vmbus_open(device->channel,
+	ret = vmbus_open_channel(device->channel,
 		INPUTVSC_SEND_RING_BUFFER_SIZE,
 		INPUTVSC_RECV_RING_BUFFER_SIZE,
 		NULL,
@@ -544,7 +544,7 @@ static int mousevsc_resume(struct hv_device *dev)
 {
 	int ret;
 
-	ret = vmbus_open(dev->channel,
+	ret = vmbus_open_channel(dev->channel,
 			 INPUTVSC_SEND_RING_BUFFER_SIZE,
 			 INPUTVSC_RECV_RING_BUFFER_SIZE,
 			 NULL, 0,

--- a/drivers/hv/channel.c
+++ b/drivers/hv/channel.c
@@ -632,8 +632,8 @@ static void vmbus_free_requestor(struct vmbus_requestor *rqstor)
 }
 
 static int __vmbus_open(struct vmbus_channel *newchannel,
-		       void *userdata, u32 userdatalen,
-		       void (*onchannelcallback)(void *context), void *context)
+		       void *userdata, u32 userdatalen, bool channelapiv1,
+		       void *onchannelcallback, void *context)
 {
 	struct vmbus_channel_open_channel *open_msg;
 	struct vmbus_channel_msginfo *open_info = NULL;
@@ -658,7 +658,17 @@ static int __vmbus_open(struct vmbus_channel *newchannel,
 	}
 
 	newchannel->state = CHANNEL_OPENING_STATE;
-	newchannel->onchannel_callback = onchannelcallback;
+
+	if (channelapiv1) {
+		newchannel->onchannel_callback = NULL;
+		newchannel->onchannel_callback_v1 = onchannelcallback;
+		printk("__vmbus_open: using v1");
+	} else {
+		newchannel->onchannel_callback = onchannelcallback;
+		newchannel->onchannel_callback_v1 = NULL;
+		printk("__vmbus_open: using new callback - SHOULD NOT HIT");
+	}
+
 	newchannel->channel_callback_context = context;
 
 	if (!newchannel->max_pkt_size)
@@ -775,9 +785,21 @@ error_clean_ring:
 int vmbus_connect_ring(struct vmbus_channel *newchannel,
 		       void (*onchannelcallback)(void *context), void *context)
 {
-	return  __vmbus_open(newchannel, NULL, 0, onchannelcallback, context);
+	bool channelapiv1 = true;
+	return  __vmbus_open(newchannel, NULL, 0, channelapiv1, onchannelcallback, context);
 }
 EXPORT_SYMBOL_GPL(vmbus_connect_ring);
+
+/*
+ * vmbus_connect_ring - Open the channel but reuse ring buffer
+ */
+int vmbus_connect_ring_channel(struct vmbus_channel *newchannel,
+		       onchannel_t *onchannelcallback, void *context)
+{
+	bool channelapiv1 = false;
+	return  __vmbus_open(newchannel, NULL, 0, channelapiv1, onchannelcallback, context);
+}
+EXPORT_SYMBOL_GPL(vmbus_connect_ring_channel);
 
 /*
  * vmbus_open - Open the specified channel.
@@ -788,6 +810,7 @@ int vmbus_open(struct vmbus_channel *newchannel,
 	       void (*onchannelcallback)(void *context), void *context)
 {
 	int err;
+	bool channelapiv1 = true;
 
 	err = vmbus_alloc_ring(newchannel, send_ringbuffer_size,
 			       recv_ringbuffer_size);
@@ -795,13 +818,38 @@ int vmbus_open(struct vmbus_channel *newchannel,
 		return err;
 
 	err = __vmbus_open(newchannel, userdata, userdatalen,
-			   onchannelcallback, context);
+			   channelapiv1, onchannelcallback, context);
 	if (err)
 		vmbus_free_ring(newchannel);
 
 	return err;
 }
 EXPORT_SYMBOL_GPL(vmbus_open);
+
+/*
+ * vmbus_open - Open the specified channel.
+ */
+int vmbus_open_channel(struct vmbus_channel *newchannel,
+	       u32 send_ringbuffer_size, u32 recv_ringbuffer_size,
+	       void *userdata, u32 userdatalen,
+	       onchannel_t *onchannelcallback, void *context)
+{
+	int err;
+	bool channelapiv1 = false;
+
+	err = vmbus_alloc_ring(newchannel, send_ringbuffer_size,
+			       recv_ringbuffer_size);
+	if (err)
+		return err;
+
+	err = __vmbus_open(newchannel, userdata, userdatalen,
+			   channelapiv1, onchannelcallback, context);
+	if (err)
+		vmbus_free_ring(newchannel);
+
+	return err;
+}
+EXPORT_SYMBOL_GPL(vmbus_open_channel);
 
 /*
  * vmbus_teardown_gpadl -Teardown the specified GPADL handle
@@ -895,6 +943,7 @@ void vmbus_reset_channel_cb(struct vmbus_channel *channel)
 	/* See the inline comments in vmbus_chan_sched(). */
 	spin_lock_irqsave(&channel->sched_lock, flags);
 	channel->onchannel_callback = NULL;
+	channel->onchannel_callback_v1 = NULL;
 	spin_unlock_irqrestore(&channel->sched_lock, flags);
 
 	channel->sc_creation_callback = NULL;

--- a/drivers/hv/channel.c
+++ b/drivers/hv/channel.c
@@ -632,8 +632,8 @@ static void vmbus_free_requestor(struct vmbus_requestor *rqstor)
 }
 
 static int __vmbus_open(struct vmbus_channel *newchannel,
-		       void *userdata, u32 userdatalen, bool channelapiv1,
-		       void *onchannelcallback, void *context)
+		       void *userdata, u32 userdatalen,
+		       onchannel_t *onchannelcallback, void *context)
 {
 	struct vmbus_channel_open_channel *open_msg;
 	struct vmbus_channel_msginfo *open_info = NULL;
@@ -659,15 +659,8 @@ static int __vmbus_open(struct vmbus_channel *newchannel,
 
 	newchannel->state = CHANNEL_OPENING_STATE;
 
-	if (channelapiv1) {
-		newchannel->onchannel_callback = NULL;
-		newchannel->onchannel_callback_v1 = onchannelcallback;
-		printk("__vmbus_open: using v1");
-	} else {
-		newchannel->onchannel_callback = onchannelcallback;
-		newchannel->onchannel_callback_v1 = NULL;
-		printk("__vmbus_open: using new callback - SHOULD NOT HIT");
-	}
+	printk("v2 callback used!");
+	newchannel->onchannel_callback = onchannelcallback;
 
 	newchannel->channel_callback_context = context;
 
@@ -782,49 +775,12 @@ error_clean_ring:
 /*
  * vmbus_connect_ring - Open the channel but reuse ring buffer
  */
-int vmbus_connect_ring(struct vmbus_channel *newchannel,
-		       void (*onchannelcallback)(void *context), void *context)
-{
-	bool channelapiv1 = true;
-	return  __vmbus_open(newchannel, NULL, 0, channelapiv1, onchannelcallback, context);
-}
-EXPORT_SYMBOL_GPL(vmbus_connect_ring);
-
-/*
- * vmbus_connect_ring - Open the channel but reuse ring buffer
- */
 int vmbus_connect_ring_channel(struct vmbus_channel *newchannel,
 		       onchannel_t *onchannelcallback, void *context)
 {
-	bool channelapiv1 = false;
-	return  __vmbus_open(newchannel, NULL, 0, channelapiv1, onchannelcallback, context);
+	return  __vmbus_open(newchannel, NULL, 0, onchannelcallback, context);
 }
 EXPORT_SYMBOL_GPL(vmbus_connect_ring_channel);
-
-/*
- * vmbus_open - Open the specified channel.
- */
-int vmbus_open(struct vmbus_channel *newchannel,
-	       u32 send_ringbuffer_size, u32 recv_ringbuffer_size,
-	       void *userdata, u32 userdatalen,
-	       void (*onchannelcallback)(void *context), void *context)
-{
-	int err;
-	bool channelapiv1 = true;
-
-	err = vmbus_alloc_ring(newchannel, send_ringbuffer_size,
-			       recv_ringbuffer_size);
-	if (err)
-		return err;
-
-	err = __vmbus_open(newchannel, userdata, userdatalen,
-			   channelapiv1, onchannelcallback, context);
-	if (err)
-		vmbus_free_ring(newchannel);
-
-	return err;
-}
-EXPORT_SYMBOL_GPL(vmbus_open);
 
 /*
  * vmbus_open - Open the specified channel.
@@ -835,7 +791,6 @@ int vmbus_open_channel(struct vmbus_channel *newchannel,
 	       onchannel_t *onchannelcallback, void *context)
 {
 	int err;
-	bool channelapiv1 = false;
 
 	err = vmbus_alloc_ring(newchannel, send_ringbuffer_size,
 			       recv_ringbuffer_size);
@@ -843,7 +798,7 @@ int vmbus_open_channel(struct vmbus_channel *newchannel,
 		return err;
 
 	err = __vmbus_open(newchannel, userdata, userdatalen,
-			   channelapiv1, onchannelcallback, context);
+			onchannelcallback, context);
 	if (err)
 		vmbus_free_ring(newchannel);
 
@@ -943,7 +898,6 @@ void vmbus_reset_channel_cb(struct vmbus_channel *channel)
 	/* See the inline comments in vmbus_chan_sched(). */
 	spin_lock_irqsave(&channel->sched_lock, flags);
 	channel->onchannel_callback = NULL;
-	channel->onchannel_callback_v1 = NULL;
 	spin_unlock_irqrestore(&channel->sched_lock, flags);
 
 	channel->sc_creation_callback = NULL;

--- a/drivers/hv/connection.c
+++ b/drivers/hv/connection.c
@@ -393,7 +393,8 @@ struct vmbus_channel *relid2channel(u32 relid)
 void vmbus_on_event(unsigned long data)
 {
 	struct vmbus_channel *channel = (void *) data;
-	void (*callback_fn)(void *context);
+	void (*callback_fn_v1)(void *context);
+	onchannel_t *callback_fn;
 
 	trace_vmbus_on_event(channel);
 
@@ -403,11 +404,17 @@ void vmbus_on_event(unsigned long data)
 	 * there is no driver handling the device. An
 	 * unloading driver sets the onchannel_callback to NULL.
 	 */
-	callback_fn = READ_ONCE(channel->onchannel_callback);
-	if (unlikely(!callback_fn))
+	if (channel->onchannel_callback_v1 != NULL) {
+		callback_fn_v1 = READ_ONCE(channel->onchannel_callback_v1);
+		(*callback_fn_v1)(channel->channel_callback_context);
+		printk("v1 callback used");
+	} else if (channel->onchannel_callback != NULL) {
+		callback_fn = READ_ONCE(channel->onchannel_callback);
+		(*callback_fn)(channel->channel_callback_context, channel);
+		printk("v2 callback used - SHOULD NOT HAPPEN");
+	} else {
 		return;
-
-	(*callback_fn)(channel->channel_callback_context);
+	}
 
 	if (channel->callback_mode != HV_CALL_BATCHED)
 		return;

--- a/drivers/hv/connection.c
+++ b/drivers/hv/connection.c
@@ -393,7 +393,6 @@ struct vmbus_channel *relid2channel(u32 relid)
 void vmbus_on_event(unsigned long data)
 {
 	struct vmbus_channel *channel = (void *) data;
-	void (*callback_fn_v1)(void *context);
 	onchannel_t *callback_fn;
 
 	trace_vmbus_on_event(channel);
@@ -404,17 +403,13 @@ void vmbus_on_event(unsigned long data)
 	 * there is no driver handling the device. An
 	 * unloading driver sets the onchannel_callback to NULL.
 	 */
-	if (channel->onchannel_callback_v1 != NULL) {
-		callback_fn_v1 = READ_ONCE(channel->onchannel_callback_v1);
-		(*callback_fn_v1)(channel->channel_callback_context);
-		printk("v1 callback used");
-	} else if (channel->onchannel_callback != NULL) {
-		callback_fn = READ_ONCE(channel->onchannel_callback);
-		(*callback_fn)(channel->channel_callback_context, channel);
-		printk("v2 callback used - SHOULD NOT HAPPEN");
-	} else {
+
+	printk("v2 callback used!");
+	callback_fn = READ_ONCE(channel->onchannel_callback);
+	if (unlikely(!callback_fn))
 		return;
-	}
+
+	(*callback_fn)(channel->channel_callback_context, channel);
 
 	if (channel->callback_mode != HV_CALL_BATCHED)
 		return;

--- a/drivers/hv/hv_balloon.c
+++ b/drivers/hv/hv_balloon.c
@@ -1407,7 +1407,7 @@ static void balloon_down(struct hv_dynmem_device *dm,
 	dm->state = DM_INITIALIZED;
 }
 
-static void balloon_onchannelcallback(void *context);
+static void balloon_onchannelcallback(void *context, struct vmbus_channel *chan);
 
 static int dm_thread_func(void *dm_dev)
 {
@@ -1511,7 +1511,7 @@ static void cap_resp(struct hv_dynmem_device *dm,
 	complete(&dm->host_event);
 }
 
-static void balloon_onchannelcallback(void *context)
+static void balloon_onchannelcallback(void *context, struct vmbus_channel *chan)
 {
 	struct hv_device *dev = context;
 	u32 recvlen;
@@ -1770,7 +1770,7 @@ static int balloon_connect_vsp(struct hv_device *dev)
 	 */
 	dev->channel->max_pkt_size = HV_HYP_PAGE_SIZE * 2;
 
-	ret = vmbus_open(dev->channel, dm_ring_size, dm_ring_size, NULL, 0,
+	ret = vmbus_open_channel(dev->channel, dm_ring_size, dm_ring_size, NULL, 0,
 			 balloon_onchannelcallback, dev);
 	if (ret)
 		return ret;

--- a/drivers/hv/hv_kvp.c
+++ b/drivers/hv/hv_kvp.c
@@ -632,7 +632,7 @@ response_done:
  * we stash away the transaction state in a set of global variables.
  */
 
-void hv_kvp_onchannelcallback(void *context)
+void hv_kvp_onchannelcallback(void *context, struct vmbus_channel *chan)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;

--- a/drivers/hv/hv_snapshot.c
+++ b/drivers/hv/hv_snapshot.c
@@ -288,7 +288,7 @@ vss_respond_to_host(int error)
  * The host ensures that only one VSS transaction can be active at a time.
  */
 
-void hv_vss_onchannelcallback(void *context)
+void hv_vss_onchannelcallback(void *context, struct vmbus_channel *chan)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;

--- a/drivers/hv/hv_util.c
+++ b/drivers/hv/hv_util.c
@@ -115,7 +115,8 @@ static int hv_shutdown_init(struct hv_util_service *srv)
 	return 0;
 }
 
-static void shutdown_onchannelcallback(void *context);
+static void shutdown_onchannelcallback(void *context,
+	struct vmbus_channel *chan);
 static struct hv_util_service util_shutdown = {
 	.util_cb = shutdown_onchannelcallback,
 	.util_init = hv_shutdown_init,
@@ -125,7 +126,8 @@ static int hv_timesync_init(struct hv_util_service *srv);
 static int hv_timesync_pre_suspend(void);
 static void hv_timesync_deinit(void);
 
-static void timesync_onchannelcallback(void *context);
+static void timesync_onchannelcallback(void *context,
+	struct vmbus_channel *chan);
 static struct hv_util_service util_timesynch = {
 	.util_cb = timesync_onchannelcallback,
 	.util_init = hv_timesync_init,
@@ -133,7 +135,8 @@ static struct hv_util_service util_timesynch = {
 	.util_deinit = hv_timesync_deinit,
 };
 
-static void heartbeat_onchannelcallback(void *context);
+static void heartbeat_onchannelcallback(void *context,
+	struct vmbus_channel *chan);
 static struct hv_util_service util_heartbeat = {
 	.util_cb = heartbeat_onchannelcallback,
 };
@@ -174,7 +177,7 @@ static DECLARE_WORK(shutdown_work, perform_shutdown);
  */
 static DECLARE_WORK(restart_work, perform_restart);
 
-static void shutdown_onchannelcallback(void *context)
+static void shutdown_onchannelcallback(void *context, struct vmbus_channel *chan)
 {
 	struct vmbus_channel *channel = context;
 	struct work_struct *work = NULL;
@@ -412,7 +415,7 @@ static inline void adj_guesttime(u64 hosttime, u64 reftime, u8 adj_flags)
 /*
  * Time Sync Channel message handler.
  */
-static void timesync_onchannelcallback(void *context)
+static void timesync_onchannelcallback(void *context, struct vmbus_channel *chan)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;
@@ -505,7 +508,7 @@ static void timesync_onchannelcallback(void *context)
  * Every two seconds, Hyper-V send us a heartbeat request message.
  * we respond to this message, and Hyper-V knows we are alive.
  */
-static void heartbeat_onchannelcallback(void *context)
+static void heartbeat_onchannelcallback(void *context, struct vmbus_channel *chan)
 {
 	struct vmbus_channel *channel = context;
 	u32 recvlen;
@@ -607,7 +610,7 @@ static int util_probe(struct hv_device *dev,
 
 	hv_set_drvdata(dev, srv);
 
-	ret = vmbus_open(dev->channel, HV_UTIL_RING_SEND_SIZE,
+	ret = vmbus_open_channel(dev->channel, HV_UTIL_RING_SEND_SIZE,
 			 HV_UTIL_RING_RECV_SIZE, NULL, 0, srv->util_cb,
 			 dev->channel);
 	if (ret)
@@ -665,7 +668,7 @@ static int util_resume(struct hv_device *dev)
 			return ret;
 	}
 
-	ret = vmbus_open(dev->channel, HV_UTIL_RING_SEND_SIZE,
+	ret = vmbus_open_channel(dev->channel, HV_UTIL_RING_SEND_SIZE,
 			 HV_UTIL_RING_RECV_SIZE, NULL, 0, srv->util_cb,
 			 dev->channel);
 	return ret;

--- a/drivers/hv/hyperv_vmbus.h
+++ b/drivers/hv/hyperv_vmbus.h
@@ -373,19 +373,19 @@ int hv_kvp_init(struct hv_util_service *srv);
 void hv_kvp_deinit(void);
 int hv_kvp_pre_suspend(void);
 int hv_kvp_pre_resume(void);
-void hv_kvp_onchannelcallback(void *context);
+onchannel_t hv_kvp_onchannelcallback;
 
 int hv_vss_init(struct hv_util_service *srv);
 void hv_vss_deinit(void);
 int hv_vss_pre_suspend(void);
 int hv_vss_pre_resume(void);
-void hv_vss_onchannelcallback(void *context);
+onchannel_t hv_vss_onchannelcallback;
 
 int hv_fcopy_init(struct hv_util_service *srv);
 void hv_fcopy_deinit(void);
 int hv_fcopy_pre_suspend(void);
 int hv_fcopy_pre_resume(void);
-void hv_fcopy_onchannelcallback(void *context);
+onchannel_t hv_fcopy_onchannelcallback;
 void vmbus_initiate_unload(bool crash);
 
 static inline void hv_poll_channel(struct vmbus_channel *channel,

--- a/drivers/input/serio/hyperv-keyboard.c
+++ b/drivers/input/serio/hyperv-keyboard.c
@@ -235,7 +235,7 @@ static void hv_kbd_handle_received_packet(struct hv_device *hv_dev,
 	}
 }
 
-static void hv_kbd_on_channel_callback(void *context)
+static void hv_kbd_on_channel_callback(void *context, struct vmbus_channel *channel)
 {
 	struct vmpacket_descriptor *desc;
 	struct hv_device *hv_dev = context;
@@ -342,7 +342,7 @@ static int hv_kbd_probe(struct hv_device *hv_dev,
 	hv_serio->start = hv_kbd_start;
 	hv_serio->stop = hv_kbd_stop;
 
-	error = vmbus_open(hv_dev->channel,
+	error = vmbus_open_channel(hv_dev->channel,
 			   KBD_VSC_SEND_RING_BUFFER_SIZE,
 			   KBD_VSC_RECV_RING_BUFFER_SIZE,
 			   NULL, 0,
@@ -391,7 +391,7 @@ static int hv_kbd_resume(struct hv_device *hv_dev)
 {
 	int ret;
 
-	ret = vmbus_open(hv_dev->channel,
+	ret = vmbus_open_channel(hv_dev->channel,
 			 KBD_VSC_SEND_RING_BUFFER_SIZE,
 			 KBD_VSC_RECV_RING_BUFFER_SIZE,
 			 NULL, 0,

--- a/drivers/net/hyperv/hyperv_net.h
+++ b/drivers/net/hyperv/hyperv_net.h
@@ -237,7 +237,7 @@ void netvsc_linkstatus_callback(struct net_device *net,
 int netvsc_recv_callback(struct net_device *net,
 			 struct netvsc_device *nvdev,
 			 struct netvsc_channel *nvchan);
-void netvsc_channel_cb(void *context);
+void netvsc_channel_cb(void *context, struct vmbus_channel *channel);
 int netvsc_poll(struct napi_struct *napi, int budget);
 
 void netvsc_xdp_xmit(struct sk_buff *skb, struct net_device *ndev);

--- a/drivers/net/hyperv/netvsc.c
+++ b/drivers/net/hyperv/netvsc.c
@@ -1693,10 +1693,9 @@ int netvsc_poll(struct napi_struct *napi, int budget)
 /* Call back when data is available in host ring buffer.
  * Processing is deferred until network softirq (NAPI)
  */
-void netvsc_channel_cb(void *context)
+void netvsc_channel_cb(void *context, struct vmbus_channel *channel)
 {
 	struct netvsc_channel *nvchan = context;
-	struct vmbus_channel *channel = nvchan->channel;
 	struct hv_ring_buffer_info *rbi = &channel->inbound;
 
 	/* preload first vmpacket descriptor */
@@ -1774,7 +1773,7 @@ struct netvsc_device *netvsc_device_add(struct hv_device *device,
 	device->channel->rqstor_size = netvsc_rqstor_size(netvsc_ring_bytes);
 	device->channel->max_pkt_size = NETVSC_MAX_PKT_SIZE;
 
-	ret = vmbus_open(device->channel, netvsc_ring_bytes,
+	ret = vmbus_open_channel(device->channel, netvsc_ring_bytes,
 			 netvsc_ring_bytes,  NULL, 0,
 			 netvsc_channel_cb, net_device->chan_table);
 

--- a/drivers/net/hyperv/rndis_filter.c
+++ b/drivers/net/hyperv/rndis_filter.c
@@ -1266,7 +1266,7 @@ static void netvsc_sc_open(struct vmbus_channel *new_sc)
 	new_sc->rqstor_size = netvsc_rqstor_size(netvsc_ring_bytes);
 	new_sc->max_pkt_size = NETVSC_MAX_PKT_SIZE;
 
-	ret = vmbus_open(new_sc, netvsc_ring_bytes,
+	ret = vmbus_open_channel(new_sc, netvsc_ring_bytes,
 			 netvsc_ring_bytes, NULL, 0,
 			 netvsc_channel_cb, nvchan);
 	if (ret == 0)

--- a/drivers/uio/uio_hv_generic.c
+++ b/drivers/uio/uio_hv_generic.c
@@ -92,9 +92,8 @@ hv_uio_irqcontrol(struct uio_info *info, s32 irq_state)
 /*
  * Callback from vmbus_event when something is in inbound ring.
  */
-static void hv_uio_channel_cb(void *context)
+static void hv_uio_channel_cb(void *context, struct vmbus_channel *chan)
 {
-	struct vmbus_channel *chan = context;
 	struct hv_device *hv_dev = chan->device_obj;
 	struct hv_uio_private_data *pdata = hv_get_drvdata(hv_dev);
 
@@ -159,8 +158,8 @@ hv_uio_new_channel(struct vmbus_channel *new_sc)
 	int ret;
 
 	/* Create host communication ring */
-	ret = vmbus_open(new_sc, ring_bytes, ring_bytes, NULL, 0,
-			 hv_uio_channel_cb, new_sc);
+	ret = vmbus_open_channel(new_sc, ring_bytes, ring_bytes, NULL, 0,
+			 hv_uio_channel_cb, NULL);
 	if (ret) {
 		dev_err(device, "vmbus_open subchannel failed: %d\n", ret);
 		return;
@@ -209,8 +208,8 @@ hv_uio_open(struct uio_info *info, struct inode *inode)
 	vmbus_set_chn_rescind_callback(dev->channel, hv_uio_rescind);
 	vmbus_set_sc_create_callback(dev->channel, hv_uio_new_channel);
 
-	ret = vmbus_connect_ring(dev->channel,
-				 hv_uio_channel_cb, dev->channel);
+	ret = vmbus_connect_ring_channel(dev->channel,
+				 hv_uio_channel_cb, NULL);
 	if (ret == 0)
 		dev->channel->inbound.ring_buffer->interrupt_mask = 1;
 	else

--- a/drivers/video/fbdev/hyperv_fb.c
+++ b/drivers/video/fbdev/hyperv_fb.c
@@ -489,7 +489,7 @@ static void synthvid_recv_sub(struct hv_device *hdev)
 }
 
 /* Receive callback for messages from the host */
-static void synthvid_receive(void *ctx)
+static void synthvid_receive(void *ctx, struct vmbus_channel *channel)
 {
 	struct hv_device *hdev = ctx;
 	struct fb_info *info = hv_get_drvdata(hdev);
@@ -616,7 +616,7 @@ static int synthvid_connect_vsp(struct hv_device *hdev)
 	struct hvfb_par *par = info->par;
 	int ret;
 
-	ret = vmbus_open(hdev->channel, RING_BUFSIZE, RING_BUFSIZE,
+	ret = vmbus_open_channel(hdev->channel, RING_BUFSIZE, RING_BUFSIZE,
 			 NULL, 0, synthvid_receive, hdev);
 	if (ret) {
 		pr_err("Unable to open vmbus channel\n");

--- a/include/linux/hyperv.h
+++ b/include/linux/hyperv.h
@@ -1575,7 +1575,7 @@ void vmbus_free_mmio(resource_size_t start, resource_size_t size);
 struct hv_util_service {
 	u8 *recv_buffer;
 	void *channel;
-	void (*util_cb)(void *);
+	onchannel_t *util_cb;
 	int (*util_init)(struct hv_util_service *);
 	void (*util_deinit)(void);
 	int (*util_pre_suspend)(void);

--- a/include/linux/hyperv.h
+++ b/include/linux/hyperv.h
@@ -888,7 +888,6 @@ struct vmbus_channel {
 
 	/* Channel callback's invoked in softirq context */
 	struct tasklet_struct callback_event;
-	void (*onchannel_callback_v1)(void *context);
 	onchannel_t *onchannel_callback;
 	void *channel_callback_context;
 
@@ -1200,21 +1199,10 @@ int vmbus_alloc_ring(struct vmbus_channel *channel,
 		     u32 send_size, u32 recv_size);
 void vmbus_free_ring(struct vmbus_channel *channel);
 
-int vmbus_connect_ring(struct vmbus_channel *channel,
-		       void (*onchannel_callback)(void *context),
-		       void *context);
 int vmbus_connect_ring_channel(struct vmbus_channel *channel,
 		       onchannel_t *onchannel_callback,
 		       void *context);
 int vmbus_disconnect_ring(struct vmbus_channel *channel);
-
-extern int vmbus_open(struct vmbus_channel *channel,
-			    u32 send_ringbuffersize,
-			    u32 recv_ringbuffersize,
-			    void *userdata,
-			    u32 userdatalen,
-			    void (*onchannel_callback)(void *context),
-			    void *context);
 
 extern int vmbus_open_channel(struct vmbus_channel *channel,
 			    u32 send_ringbuffersize,

--- a/include/linux/hyperv.h
+++ b/include/linux/hyperv.h
@@ -837,6 +837,8 @@ struct vmbus_gpadl {
 	bool decrypted;
 };
 
+typedef void onchannel_t(void *context, struct vmbus_channel *chan);
+
 struct vmbus_channel {
 	struct list_head listentry;
 
@@ -886,7 +888,8 @@ struct vmbus_channel {
 
 	/* Channel callback's invoked in softirq context */
 	struct tasklet_struct callback_event;
-	void (*onchannel_callback)(void *context);
+	void (*onchannel_callback_v1)(void *context);
+	onchannel_t *onchannel_callback;
 	void *channel_callback_context;
 
 	void (*change_target_cpu_callback)(struct vmbus_channel *channel,
@@ -1200,6 +1203,9 @@ void vmbus_free_ring(struct vmbus_channel *channel);
 int vmbus_connect_ring(struct vmbus_channel *channel,
 		       void (*onchannel_callback)(void *context),
 		       void *context);
+int vmbus_connect_ring_channel(struct vmbus_channel *channel,
+		       onchannel_t *onchannel_callback,
+		       void *context);
 int vmbus_disconnect_ring(struct vmbus_channel *channel);
 
 extern int vmbus_open(struct vmbus_channel *channel,
@@ -1208,6 +1214,14 @@ extern int vmbus_open(struct vmbus_channel *channel,
 			    void *userdata,
 			    u32 userdatalen,
 			    void (*onchannel_callback)(void *context),
+			    void *context);
+
+extern int vmbus_open_channel(struct vmbus_channel *channel,
+			    u32 send_ringbuffersize,
+			    u32 recv_ringbuffersize,
+			    void *userdata,
+			    u32 userdatalen,
+			    onchannel_t *onchannelcallback,
 			    void *context);
 
 extern void vmbus_close(struct vmbus_channel *channel);

--- a/net/vmw_vsock/hyperv_transport.c
+++ b/net/vmw_vsock/hyperv_transport.c
@@ -244,13 +244,9 @@ static int hvs_send_data(struct vmbus_channel *chan,
 	return __hvs_send_data(chan, &send_buf->hdr, to_write);
 }
 
-static void hvs_channel_cb(void *ctx)
+static void hvs_channel_cb(void *ctx, struct vmbus_channel *chan)
 {
 	struct sock *sk = (struct sock *)ctx;
-	struct vsock_sock *vsk = vsock_sk(sk);
-	struct hvsock *hvs = vsk->trans;
-	struct vmbus_channel *chan = hvs->chan;
-
 	if (hvs_channel_readable(chan))
 		sk->sk_data_ready(sk);
 
@@ -383,7 +379,7 @@ static void hvs_open_connection(struct vmbus_channel *chan)
 
 	chan->max_pkt_size = HVS_MAX_PKT_SIZE;
 
-	ret = vmbus_open(chan, sndbuf, rcvbuf, NULL, 0, hvs_channel_cb,
+	ret = vmbus_open_channel(chan, sndbuf, rcvbuf, NULL, 0, hvs_channel_cb,
 			 conn_from_host ? new : sk);
 	if (ret != 0) {
 		if (conn_from_host) {


### PR DESCRIPTION
This patchset introduces new function apis for "vmbus_open" and "vmbus_connect_ring". The current api passes the channel as a part of the context. The new functions add an additional parameter for the vmbus channel explicitly. This new function api is in preparation for Rust integration.

Rust code is built to create sound code blocks and to prevent the user from ever entering into undefined behavior. Rust will need a new type state to prevent writing and reading from channels which are not yet open. However, this requires the channel to be separate from the context as the channel may not have been opened yet. 

An implementation of this can be seen at https://github.com/wedsonaf/linux/tree/hv

**Background**
vmbus_channel is given callback function by __vmbus_open
__vmbus_open called by vmbus_open
drvier -> vmbus_add_channel_work -> vmbus_open -> __vmbus_open -> sets channel callback function

**API changes**
vmbus_open -> vmbus_open_channel
vmbus_connect_ring -> vmbus_connect_ring_channel

**internal function changes during trasnsition**
- __vmbus_open
    - accepts a boolean on if it should use the v1 callback api
    
- vmbus_channel struct 
    - original callback function renamed to `onchannel_callback_v1`
    `void (*onchannel_callback)(void *context);` -> `void (*onchannel_callback_v1)(void *context);`
    - added new callback function which requires context and channel
    `typedef void onchannel_t(void *context, struct vmbus_channel *chan);`
     `void (*onchannel_callback_v1)(void *context);`


Checks:
- [x] Builds with CONFIG_HYPERV
- [ ] Builds without CONFIG_HYPERV

TODO
- clean up commits to have full messages
- cleanup printks
- clean up comments in code (still reference vmbus_open)
- add comments in code when introducing transition code which later needs to be cleaned up
- run tests without hyperv-modules enabled
- run patch cleanup tools
- send to linux-hyperv